### PR TITLE
DP 1324 - Add cpu frequency to telegraf

### DIFF
--- a/files/telegraf.conf
+++ b/files/telegraf.conf
@@ -4188,12 +4188,12 @@
 #   ## Usage of this setting is discouraged since it will be deprecated in favor of 'perdevice_include'.
 #   ## Default value is 'true' for backwards compatibility, please set it to 'false' so that 'perdevice_include' setting
 #   ## is honored.
-  perdevice = true
+  perdevice = false
 #
 #   ## Specifies for which classes a per-device metric should be issued
 #   ## Possible values are 'cpu' (cpu0, cpu1, ...), 'blkio' (8:0, 8:1, ...) and 'network' (eth0, eth1, ...)
 #   ## Please note that this setting has no effect if 'perdevice' is set to 'true'
-#   perdevice_include = ["cpu"]
+  perdevice_include = ["cpu", "blkio", "network"]
 #
 #   ## Whether to report for each container total blkio and network stats or not.
 #   ## Usage of this setting is discouraged since it will be deprecated in favor of 'total_include'.
@@ -4993,31 +4993,31 @@
   timeout = "5s"
 
 
-# # Intel PowerStat plugin enables monitoring of platform metrics (power, TDP)
-# # and per-CPU metrics like temperature, power and utilization.
+# Intel PowerStat plugin enables monitoring of platform metrics (power, TDP)
+# and per-CPU metrics like temperature, power and utilization.
 # [[inputs.intel_powerstat]]
-#   ## The user can choose which package metrics are monitored by the plugin with
-#   ## the package_metrics setting:
-#   ## - The default, will collect "current_power_consumption",
-#   ##   "current_dram_power_consumption" and "thermal_design_power"
-#   ## - Leaving this setting empty means no package metrics will be collected
-#   ## - Finally, a user can specify individual metrics to capture from the
-#   ##   supported options list
-#   ## Supported options:
-#   ##   "current_power_consumption", "current_dram_power_consumption",
-#   ##   "thermal_design_power", "max_turbo_frequency", "uncore_frequency"
-#   # package_metrics = ["current_power_consumption", "current_dram_power_consumption", "thermal_design_power"]
-#
-#   ## The user can choose which per-CPU metrics are monitored by the plugin in
-#   ## cpu_metrics array.
-#   ## Empty or missing array means no per-CPU specific metrics will be collected
-#   ## by the plugin.
-#   ## Supported options:
-#   ##   "cpu_frequency", "cpu_c0_state_residency", "cpu_c1_state_residency",
-#   ##   "cpu_c6_state_residency", "cpu_busy_cycles", "cpu_temperature",
-#   ##   "cpu_busy_frequency"
-#   ## ATTENTION: cpu_busy_cycles is DEPRECATED - use cpu_c0_state_residency
-#   # cpu_metrics = []
+  ## The user can choose which package metrics are monitored by the plugin with
+  ## the package_metrics setting:
+  ## - The default, will collect "current_power_consumption",
+  ##   "current_dram_power_consumption" and "thermal_design_power"
+  ## - Leaving this setting empty means no package metrics will be collected
+  ## - Finally, a user can specify individual metrics to capture from the
+  ##   supported options list
+  ## Supported options:
+  ##   "current_power_consumption", "current_dram_power_consumption",
+  ##   "thermal_design_power", "max_turbo_frequency", "uncore_frequency"
+  # package_metrics = ["current_power_consumption", "current_dram_power_consumption", "thermal_design_power"]
+
+  ## The user can choose which per-CPU metrics are monitored by the plugin in
+  ## cpu_metrics array.
+  ## Empty or missing array means no per-CPU specific metrics will be collected
+  ## by the plugin.
+  ## Supported options:
+  ##   "cpu_frequency", "cpu_c0_state_residency", "cpu_c1_state_residency",
+  ##   "cpu_c6_state_residency", "cpu_busy_cycles", "cpu_temperature",
+  ##   "cpu_busy_frequency"
+  ## ATTENTION: cpu_busy_cycles is DEPRECATED - use cpu_c0_state_residency
+  # cpu_metrics = ["cpu_frequency", "cpu_temperature"]
 
 
 # # Collect statistics about itself
@@ -5453,17 +5453,17 @@
 
 
 # Provides Linux CPU metrics
-# [[inputs.linux_cpu]]
-#   ## Path for sysfs filesystem.
-#   ## See https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt
-#   ## Defaults:
-#   host_sys = "/hostfs/sys"
+[[inputs.linux_cpu]]
+  ## Path for sysfs filesystem.
+  ## See https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt
+  ## Defaults:
+  host_sys = "/hostfs/sys"
 
 #   ## CPU metrics collected by the plugin.
 #   ## Supported options:
 #   ## "cpufreq", "thermal"
 #   ## Defaults:
-#   metrics = ["cpufreq", "thermal"]
+  metrics = ["cpufreq", "thermal"]
 
 
 # # Provides Linux sysctl fs metrics


### PR DESCRIPTION
Changed the telegraf.conf file to include cpu frequency.

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
