### PR TITLE
DP-1324: add test in entrypoint on enabling linux_cpu input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ LABEL environment="develop"
 COPY files/telegraf.conf /etc/telegraf/telegraf.conf
 COPY files/entrypoint.sh /entrypoint.sh
 
+RUN chmod o+w /etc/telegraf/telegraf.conf
+
 # Rest is upstream

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ LABEL movai="telegraf"
 LABEL environment="develop"
 
 COPY files/telegraf.conf /etc/telegraf/telegraf.conf
+COPY files/entrypoint.sh /entrypoint.sh
 
 # Rest is upstream

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 
 if [ "$enable_plugin" == "true" ] && ! grep linux_cpu /etc/telegraf/telegraf.conf -q; then
     # Include the configuration for the [[inputs.linux_cpu]] plugin
-    cat <<EOF > /etc/telegraf/telegraf.conf
+    cat <<EOF >> /etc/telegraf/telegraf.conf
 
 [[inputs.linux_cpu]]
   host_sys = "/hostfs/sys"

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -10,7 +10,7 @@ else
     enable_plugin=false
 fi
 
-if [ "$enable_plugin" == "true" ]; then
+if [ "$enable_plugin" == "true" ] && ! grep linux_cpu /etc/telegraf/telegraf.conf -q; then
     # Include the configuration for the [[inputs.linux_cpu]] plugin
     cat <<EOF > /etc/telegraf/telegraf.conf
 

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+# Check if linux_cpu inputs required files exist
+if [ -d "/sys/devices/system/cpu/cpu0/cpufreq/" ] && [ -d "/sys/devices/system/cpu/cpu0/thermal_throttle/" ]; then
+    # Enable the [[inputs.linux_cpu]] plugin
+    enable_plugin=true
+else
+    # Disable the [[inputs.linux_cpu]] plugin
+    enable_plugin=false
+fi
+
+if [ "$enable_plugin" == "true" ]; then
+    # Include the configuration for the [[inputs.linux_cpu]] plugin
+    cat <<EOF > /etc/telegraf/telegraf.conf
+
+[[inputs.linux_cpu]]
+  host_sys = "/hostfs/sys"
+  metrics = ["cpufreq", "thermal"]
+EOF
+fi
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec "$@"
+else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
+
+    exec su-exec telegraf "$@"
+fi
+

--- a/files/telegraf.conf
+++ b/files/telegraf.conf
@@ -5452,20 +5452,6 @@
 #   servers = ["127.0.0.1:4010"]
 
 
-# Provides Linux CPU metrics
-[[inputs.linux_cpu]]
-  ## Path for sysfs filesystem.
-  ## See https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt
-  ## Defaults:
-  host_sys = "/hostfs/sys"
-
-#   ## CPU metrics collected by the plugin.
-#   ## Supported options:
-#   ## "cpufreq", "thermal"
-#   ## Defaults:
-  metrics = ["cpufreq", "thermal"]
-
-
 # # Provides Linux sysctl fs metrics
 # [[inputs.linux_sysctl_fs]]
 #   # no configuration


### PR DESCRIPTION
DP-1324: add test in entrypoint on enabling linux_cpu input

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

