### PR TITLE
Robustify check for linux cpu plugin

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -2,21 +2,50 @@
 set -e
 
 # Check if linux_cpu inputs required files exist
-if [ -d "/sys/devices/system/cpu/cpu0/cpufreq/" ] && [ -d "/sys/devices/system/cpu/cpu0/thermal_throttle/" ]; then
-    # Enable the [[inputs.linux_cpu]] plugin
-    enable_plugin=true
-else
-    # Disable the [[inputs.linux_cpu]] plugin
-    enable_plugin=false
+enable_plugin_cpufreq=false
+cpu_freq_files="affected_cpus base_frequency cpuinfo_max_freq cpuinfo_min_freq cpuinfo_transition_latency energy_performance_available_preferences energy_performance_preference related_cpus scaling_available_governors scaling_cur_freq scaling_driver scaling_governor scaling_max_freq scaling_min_freq scaling_setspeed"
+if [ -d "/sys/devices/system/cpu/cpu0/cpufreq/" ] ; then
+    # Enable the [[inputs.linux_cpu]] cpufreq plugin
+    enable_plugin_cpufreq=true
+    for file in $cpu_freq_files; do
+        if ! [ -f "/sys/devices/system/cpu/cpu0/cpufreq/$file" ]; then
+            enable_plugin_cpufreq=false
+            break
+        fi
+    done
 fi
 
-if [ "$enable_plugin" == "true" ] && ! grep linux_cpu /etc/telegraf/telegraf.conf -q; then
+enable_plugin_thermalthrottle=false
+thermal_throttle_files="core_throttle_count core_throttle_max_time_ms core_throttle_total_time_ms package_throttle_count package_throttle_max_time_ms package_throttle_total_time_ms"
+if [ -d "/sys/devices/system/cpu/cpu0/thermal_throttle/" ]; then
+    # Enable the [[inputs.linux_cpu]] thermal plugin
+    enable_plugin_thermalthrottle=true
+    for file in $thermal_throttle_files; do
+        if ! [ -f "/sys/devices/system/cpu/cpu0/thermal_throttle/$file" ]; then
+            enable_plugin_thermalthrottle=false
+            break
+        fi
+    done
+fi
+
+metrics=""
+if [ "$enable_plugin_cpufreq" = "true" ]; then
+    metrics="cpufreq"
+fi
+if [ "$enable_plugin_thermalthrottle" = "true" ]; then
+    if [ -n "$metrics" ]; then
+        metrics="\"$metrics\""
+    fi
+    metrics="${metrics},\"thermal\""
+fi
+
+if [ -n "$metrics" ] && ! grep linux_cpu /etc/telegraf/telegraf.conf -q; then
     # Include the configuration for the [[inputs.linux_cpu]] plugin
     cat <<EOF >> /etc/telegraf/telegraf.conf
 
 [[inputs.linux_cpu]]
   host_sys = "/hostfs/sys"
-  metrics = ["cpufreq", "thermal"]
+  metrics = [$metrics]
 EOF
 fi
 


### PR DESCRIPTION
Added conditions to use linux_cpu plugin

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
