### PR TITLE
DP-1657 - Fix telegraf configuration on workers

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -11,7 +11,7 @@ for redis_server in $redis_server_options; do
         if [ -z "$redis_servers" ]; then
             redis_servers="\"tcp://$redis_server:6379\""
         else
-            redis_servers="$redis_servers tcp://$redis_server:6379"
+            redis_servers="$redis_servers,\"tcp://$redis_server:6379\""
         fi
     fi
 done

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -16,7 +16,7 @@ for redis_server in $redis_server_options; do
     fi
 done
 
-export REDIS_SERVERS=${REDIS_SERVERS:-$(echo "$redis_servers" | sed -e 's/[^ ]\+/"&"/g' -e 's/ /,/g' -e 's/^/[/' -e 's/$/]/')}
+export REDIS_SERVERS="[$redis_servers]"
 
 echo "Using Redis servers: $REDIS_SERVERS"
 

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -2,14 +2,23 @@
 set -e
 export TELEGRAF_CONFIG_PATH=/etc/telegraf/telegraf_${TELEGRAF_CONFIG_LEVEL}.conf
 export TELEGRAF_HOSTNAME=${TELEGRAF_HOSTNAME:"telegraf"}
-# Check if Redis master server is reachable, fallback to Redis slave
-if nc -z -w 1 redis-master 6379; then
-    echo "Redis master server is reachable, so using it"
-    export REDIS_SERVER=${REDIS_SERVER:-"master"}
-elif nc -z -w 1 redis-slave 6379; then
-    echo "Redis slave server is reachable, so using it"
-    export REDIS_SERVER=${REDIS_SERVER:-"slave"}
-fi
+# Check if redis servers are available
+redis_servers=""
+redis_server_options="redis-local redis-master redis-slave"
+
+for redis_server in $redis_server_options; do
+    if nc -z -w 1 $redis_server 6379 > /dev/null 2>&1; then
+        if [ -z "$redis_servers" ]; then
+            redis_servers="tcp://$redis_server:6379"
+        else
+            redis_servers="$redis_servers tcp://$redis_server:6379"
+        fi
+    fi
+done
+
+export REDIS_SERVERS=${REDIS_SERVERS:-$(echo "$redis_servers" | sed -e 's/[^ ]\+/"&"/g' -e 's/ /,/g' -e 's/^/[/' -e 's/$/]/')}
+
+echo "Using Redis servers: $REDIS_SERVERS"
 
 # Check if linux_cpu inputs required files exist
 enable_plugin_cpufreq=false

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -9,7 +9,7 @@ redis_server_options="redis-local redis-master redis-slave"
 for redis_server in $redis_server_options; do
     if nc -z -w 1 $redis_server 6379 > /dev/null 2>&1; then
         if [ -z "$redis_servers" ]; then
-            redis_servers="tcp://$redis_server:6379"
+            redis_servers="\"tcp://$redis_server:6379\""
         else
             redis_servers="$redis_servers tcp://$redis_server:6379"
         fi

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -2,6 +2,14 @@
 set -e
 export TELEGRAF_CONFIG_PATH=/etc/telegraf/telegraf_${TELEGRAF_CONFIG_LEVEL}.conf
 export TELEGRAF_HOSTNAME=${TELEGRAF_HOSTNAME:"telegraf"}
+# Check if Redis master server is reachable, fallback to Redis slave
+if nc -z -w 1 redis-master 6379; then
+    echo "Redis master server is reachable, so using it"
+    export REDIS_SERVER=${REDIS_SERVER:-"master"}
+elif nc -z -w 1 redis-slave 6379; then
+    echo "Redis slave server is reachable, so using it"
+    export REDIS_SERVER=${REDIS_SERVER:-"slave"}
+fi
 
 # Check if linux_cpu inputs required files exist
 enable_plugin_cpufreq=false

--- a/files/telegraf_debug.conf
+++ b/files/telegraf_debug.conf
@@ -63,7 +63,7 @@
 [[inputs.docker_log]]
     endpoint = "unix:///var/run/docker.sock"
 [[inputs.redis]]
-  servers = ["tcp://redis-local:6379","tcp://redis-${REDIS_SERVER}:6379"]
+  servers = ${REDIS_SERVERS}
 # [[inputs.chrony]]
 #   ## Server address of chronyd with address scheme
 #   ## If empty or not set, the plugin will mimic the behavior of chronyc and

--- a/files/telegraf_debug.conf
+++ b/files/telegraf_debug.conf
@@ -63,7 +63,7 @@
 [[inputs.docker_log]]
     endpoint = "unix:///var/run/docker.sock"
 [[inputs.redis]]
-  servers = ["tcp://redis-local:6379","tcp://redis-master:6379"]
+  servers = ["tcp://redis-local:6379","tcp://redis-${REDIS_SERVER}:6379"]
 # [[inputs.chrony]]
 #   ## Server address of chronyd with address scheme
 #   ## If empty or not set, the plugin will mimic the behavior of chronyc and

--- a/files/telegraf_production.conf
+++ b/files/telegraf_production.conf
@@ -58,7 +58,7 @@
 # [[inputs.docker_log]]
 #     endpoint = "unix:///var/run/docker.sock"
 [[inputs.redis]]
-  servers = ["tcp://redis-local:6379","tcp://redis-${REDIS_SERVER}:6379"]
+  servers = ${REDIS_SERVERS}
 # [[inputs.chrony]]
 #   ## Server address of chronyd with address scheme
 #   ## If empty or not set, the plugin will mimic the behavior of chronyc and

--- a/files/telegraf_production.conf
+++ b/files/telegraf_production.conf
@@ -58,7 +58,7 @@
 # [[inputs.docker_log]]
 #     endpoint = "unix:///var/run/docker.sock"
 [[inputs.redis]]
-  servers = ["tcp://redis-local:6379","tcp://redis-master:6379"]
+  servers = ["tcp://redis-local:6379","tcp://redis-${REDIS_SERVER}:6379"]
 # [[inputs.chrony]]
 #   ## Server address of chronyd with address scheme
 #   ## If empty or not set, the plugin will mimic the behavior of chronyc and


### PR DESCRIPTION
- Make configuration of servers for telegraf to reach dynamic and defined at entrypoint.

Tested, by installing a manager and a worker and updating their telegraf and verifying the stae of ENV vars of the telegraf processes.
On manager:
```
$  docker logs telegraf-manager-myfleet -f
Using Redis servers: ["tcp://redis-local:6379","tcp://redis-master:6379"]
2024-11-15T14:54:19Z I! Loading config: /etc/telegraf/telegraf_production.conf
```
- on monitoring page, telegraf redis dashboard is showing redis--master and redis-local data

On manager with redis disabled:
```
$ docker logs telegraf-manager-myfleet 
Using Redis servers: []
2024-11-15T15:18:36Z I! Loading config: /etc/telegraf/telegraf_production.conf
```
- on monitoring page, telegraf redis dashboard is not filled

On worker:
```
$ docker logs telegraf-member0-myfleet 
Using Redis servers: ["tcp://redis-local:6379","tcp://redis-slave:6379"]
2024-11-15T15:05:16Z I! Loading config: /etc/telegraf/telegraf_production.conf
```

---------------------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
