### PR TITLE
Feat DP-2177 : Update Telegraf version and enhance configuration for metrics output

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.4.1"
+current_version = "1.5.0"
 commit = true
 commit_args = ""
 tag = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL environment=$ENVIRONMENT
 
 # Install additional packages
 RUN command -v apk && apk add --no-cache \
-    chrony=4.6.1-r1 \
+    chrony=4.8-r2 \
     util-linux \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TELEGRAF_VERSION="1.38-alpine"
+ARG TELEGRAF_VERSION="1.39-alpine"
 FROM telegraf:${TELEGRAF_VERSION}
 
 ARG ENVIRONMENT="production"
@@ -21,6 +21,8 @@ COPY files/telegraf_production.conf /etc/telegraf/telegraf_production.conf
 COPY files/entrypoint.sh /entrypoint.sh
 
 ENV TELEGRAF_CONFIG_LEVEL=$ENVIRONMENT
+ENV METRICS_OUTPUT_URL="udp://influxdb:9096"
+ENV INFLUXDB_INPUT_ENABLED="true"
 
 RUN chmod o+w /etc/telegraf/telegraf_debug.conf /etc/telegraf/telegraf_production.conf \
     && rm -f /etc/telegraf/telegraf.conf \

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -2,6 +2,15 @@
 set -e
 export TELEGRAF_CONFIG_PATH="/etc/telegraf/telegraf_${TELEGRAF_CONFIG_LEVEL}.conf"
 export TELEGRAF_HOSTNAME="${TELEGRAF_HOSTNAME:-telegraf}"
+export METRICS_OUTPUT_URL="${METRICS_OUTPUT_URL:-udp://influxdb:9096}"
+INFLUXDB_INPUT_ENABLED="${INFLUXDB_INPUT_ENABLED:-true}"
+
+echo "Using metrics output: $METRICS_OUTPUT_URL"
+
+if [ "$INFLUXDB_INPUT_ENABLED" != "true" ] && [ -f "$TELEGRAF_CONFIG_PATH" ]; then
+    sed -i '/# __INFLUXDB_INPUT_BEGIN__/,/# __INFLUXDB_INPUT_END__/d' "$TELEGRAF_CONFIG_PATH"
+fi
+echo "InfluxDB self-monitoring input enabled: $INFLUXDB_INPUT_ENABLED"
 
 # Check if redis servers are available
 redis_servers=""

--- a/files/telegraf_debug.conf
+++ b/files/telegraf_debug.conf
@@ -21,12 +21,16 @@
   omit_hostname = false
 
 [[outputs.influxdb]]
-  urls = ["udp://influxdb:9096"]
+  # HTTP url targets Mimir's Influx ingest endpoint; udp url targets InfluxDB directly.
+  urls = ["${METRICS_OUTPUT_URL}"]
   database = "telegraf"
   retention_policy = ""
   write_consistency = "any"
   timeout = "5s"
   udp_payload = "61440B"
+  content_encoding = "gzip"
+  # Mimir has no /query endpoint, so never attempt CREATE DATABASE.
+  skip_database_creation = true
 
 # ============================================================================
 # SYSTEM METRICS - Required by perf_metrics.system module
@@ -105,9 +109,11 @@
 [[inputs.temp]]
   # CPU/Motherboard temperature monitoring
 
+# __INFLUXDB_INPUT_BEGIN__
 [[inputs.influxdb]]
   urls = ["http://influxdb:8086/debug/vars"]
   timeout = "5s"
+# __INFLUXDB_INPUT_END__
 
 [[inputs.redis]]
   servers = ${REDIS_SERVERS}

--- a/files/telegraf_production.conf
+++ b/files/telegraf_production.conf
@@ -18,12 +18,16 @@
   omit_hostname = false
 
 [[outputs.influxdb]]
-  urls = ["udp://influxdb:9096"]
+  # HTTP url targets Mimir's Influx ingest endpoint; udp url targets InfluxDB directly.
+  urls = ["${METRICS_OUTPUT_URL}"]
   database = "telegraf"
   retention_policy = ""
   write_consistency = "any"
   timeout = "5s"
   udp_payload = "61440B"
+  content_encoding = "gzip"
+  # Mimir has no /query endpoint, so never attempt CREATE DATABASE.
+  skip_database_creation = true
 
 # ============================================================================
 # TIER 1: HIGH FREQUENCY (30s) - Critical Real-time Metrics
@@ -126,10 +130,12 @@
   collect_memstats = true
 
 # InfluxDB monitoring - enabled for dashboard metrics
+# __INFLUXDB_INPUT_BEGIN__
 [[inputs.influxdb]]
   urls = ["http://influxdb:8086/debug/vars"]
   timeout = "5s"
   interval = "5m"
+# __INFLUXDB_INPUT_END__
 
 [[inputs.redis]]
   servers = ${REDIS_SERVERS}

--- a/images-manifest.yml
+++ b/images-manifest.yml
@@ -1,4 +1,4 @@
-version: 1.4.1
+version: 1.5.0
 
 images:
   - name: telegraf


### PR DESCRIPTION
This pull request updates the Telegraf Docker image and configuration to improve flexibility and control over metrics output and self-monitoring. The main changes include upgrading Telegraf and Chrony versions, introducing new environment variables for metrics output configuration, and making the InfluxDB input plugin optional via environment control.

**Image and Dependency Updates:**
- Upgraded the base Telegraf image to version `1.39-alpine` and updated the `chrony` package to `4.8-r2` for improved reliability and security. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L14-R14)

**Configuration Flexibility:**
- Added `METRICS_OUTPUT_URL` and `INFLUXDB_INPUT_ENABLED` environment variables to the `Dockerfile` and `entrypoint.sh`, allowing runtime configuration of the metrics output destination and toggling of the InfluxDB input plugin. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R24-R25) [[2]](diffhunk://#diff-2f397b3dc5284173da97ebd95ef91fad11c945bc9b11276852341729028e24afR5-R13)
- Updated `entrypoint.sh` to conditionally remove the InfluxDB input section from the Telegraf config if `INFLUXDB_INPUT_ENABLED` is not set to `true`.

**Telegraf Configuration Improvements:**
- Modified both `telegraf_production.conf` and `telegraf_debug.conf` to reference `${METRICS_OUTPUT_URL}` for the InfluxDB output plugin, and added options for gzip content encoding and skipping database creation for better compatibility with different backends. [[1]](diffhunk://#diff-4e965159246263378affea86c6828174d2739bc67aa023cc262852c332262ff0L24-R33) [[2]](diffhunk://#diff-23c1c0cdee237c917ab407c7a9b9966ec00c843b3531cd171a658bd3f7283b6eL21-R30)
- Wrapped the InfluxDB input plugin configuration in special markers (`# __INFLUXDB_INPUT_BEGIN__`/`# __INFLUXDB_INPUT_END__`) to allow for its conditional removal by the entrypoint script. [[1]](diffhunk://#diff-4e965159246263378affea86c6828174d2739bc67aa023cc262852c332262ff0R112-R116) [[2]](diffhunk://#diff-23c1c0cdee237c917ab407c7a9b9966ec00c843b3531cd171a658bd3f7283b6eR133-R138)